### PR TITLE
Add pre-filter functionality to Kafka Connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfaas-kafka-connector",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfaas-kafka-connector",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -531,6 +531,11 @@
       "requires": {
         "path-parse": "^1.0.6"
       }
+    },
+    "safe-eval": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/safe-eval/-/safe-eval-0.4.1.tgz",
+      "integrity": "sha512-wmiu4RSYVZ690RP1+cv/LxfPK1dIlEN35aW7iv4SMYdqDrHbkll4+NJcHmKm7PbCuI1df1otOcPwgcc2iFR85g=="
     },
     "semver": {
       "version": "5.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfaas-kafka-connector",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openfaas-kafka-connector",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfaas-kafka-connector",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "./src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfaas-kafka-connector",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "./src/index.js",
   "scripts": {
@@ -18,6 +18,7 @@
     "node-cron": "^2.0.3",
     "node-fetch": "^2.6.0",
     "redis": "^3.0.2",
+    "safe-eval": "^0.4.1",
     "uuid": "^3.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openfaas-kafka-connector",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "",
   "main": "./src/index.js",
   "scripts": {

--- a/src/event.service.js
+++ b/src/event.service.js
@@ -117,6 +117,9 @@ class EventService {
                 console.log(`Event: ${event.type} occurred at: ${event.occurredAt}`);
                 for(let f of subscription.functions){
                     event.metadata = {function: f.name };
+                    if (typeof f.annotations.filter === "string") {
+                        event.metadata.filter = f.annotations.filter; 
+                    }
                     const queue = this.queues.get(subscription.name);
                     let job = queue.createJob(event);
 

--- a/src/index.js
+++ b/src/index.js
@@ -132,10 +132,10 @@ async function subscribe(eventService, topic, functions){
     await eventService.subscribe(topic,
         `${topic}`, functions, concurrency, async (payload, done) => {
             console.log(`executing: ${payload.data.metadata.function}`);
-            //console.log(payload.data);
             let event = payload.data;
             try {
-                if (payload.data.metadata.filter && eval(payload.data.metadata.filter)) {
+                //If filter has been specifed, and it evaluates to true, or hasn't been specified
+                if ((payload.data.metadata.filter && eval(payload.data.metadata.filter)) || !payload.data.metadata.filter) {
                     let functionResponse = await fetch(`${faas}/function/${payload.data.metadata.function}`, {
                         method: 'post',
                         body: JSON.stringify(event),

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ async function subscribe(eventService, topic, functions){
             };
             try {
                 //If filter has been specifed, and it evaluates to true, or hasn't been specified
-                if ((payload.data.metadata.filter && safeEval(payload.data.metadata.filter, context)) || !payload.data.metadata.filter) {
+                if (!payload.data.metadata.filter || safeEval(payload.data.metadata.filter, context)) {
                     let functionResponse = await fetch(`${faas}/function/${payload.data.metadata.function}`, {
                         method: 'post',
                         body: JSON.stringify(event),

--- a/src/index.js
+++ b/src/index.js
@@ -136,9 +136,6 @@ async function subscribe(eventService, topic, functions){
             let event = payload.data;
             try {
                 if (payload.data.metadata.filter && eval(payload.data.metadata.filter)) {
-                    if (payload.data.metadata.function == "repeat") {
-                        console.log("Working");
-                    }
                     let functionResponse = await fetch(`${faas}/function/${payload.data.metadata.function}`, {
                         method: 'post',
                         body: JSON.stringify(event),


### PR DESCRIPTION
This PR adds a pre-filter to the Kafka Connector, which allows users to specify a JavaScript expression in their function's stack.yml, which will cause the function to run on the selected topics if it evaluates to true, otherwise it will ignore the event. 

To use this feature, in the function definition in your stack.yml file, specify something like this:
```
annotations:
  topic: test-stream-1
  filter: "event.content.hello !== \"world\""
```
When an event comes in on the topic test-stream-1, if the content of the event object contains an attribute `hello` which is set to the string "world", the function will not be executed, but will if this condition is not met. If the filter option is not specified in the stack.yml, all subscribed topics will continue to run the function as normal.