### PR TITLE
Plat 1057 update helm chart

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -1,0 +1,47 @@
+name: "Helm chart CI"
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  HELM_CHART_PATH: './deploy/openfaas-kafka-connector'
+  HELM_CHART_REPO_NAME: 'ratehub'
+  HELM_CHART_REPO_URL: 'cm://helm.ratehub.dev'
+
+jobs:
+  helm:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Checkout codebase'
+        uses: actions/checkout@v2
+
+      - name: 'Setup helm'
+        id: install
+        uses: azure/setup-helm@v1
+        with:
+          version: 'v3.5.2'
+
+      - name: Lint helm chart
+        run: |
+          helm lint "${HELM_CHART_PATH}"
+
+      - name: Install helm push
+        run: |
+          helm plugin install https://github.com/chartmuseum/helm-push
+
+      - name: Add helm.ratehub.dev
+        env:
+          HELM_REPO_USERNAME: ${{ secrets.RATEHUB_HELM_USER }}
+          HELM_REPO_PASSWORD: ${{ secrets.RATEHUB_HELM_PASS }}
+        run: |
+          helm repo add "${HELM_CHART_REPO_NAME}" "${HELM_CHART_REPO_URL}"
+
+      - name: Publish helm chart
+        if: github.ref == 'refs/heads/master'
+        env:
+          HELM_REPO_USERNAME: ${{ secrets.RATEHUB_HELM_USER }}
+          HELM_REPO_PASSWORD: ${{ secrets.RATEHUB_HELM_PASS }}
+        run: |
+          helm push "${HELM_CHART_PATH}" "${HELM_CHART_REPO_NAME}"

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ typings/
 .env
 /deploy/openfaas-kafka-connector/values-prod.yaml
 /deploy/openfaas-kafka-connector/values-staging.yaml
+tmp

--- a/deploy/openfaas-kafka-connector/.helmignore
+++ b/deploy/openfaas-kafka-connector/.helmignore
@@ -14,6 +14,7 @@
 *.swp
 *.bak
 *.tmp
+*.orig
 *~
 # Various IDEs
 .project

--- a/deploy/openfaas-kafka-connector/Chart.yaml
+++ b/deploy/openfaas-kafka-connector/Chart.yaml
@@ -1,5 +1,25 @@
-apiVersion: v1
-appVersion: "1.0.7"
-description: A Helm chart for ratehub's openfaas kafka connector
+apiVersion: v2
 name: openfaas-kafka-connector
-version: 1.0.0
+description: A Helm chart for ratehub's openfaas kafka connector
+icon: https://www.openfaas.com/images/openfaas/whale.png
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.4.6"

--- a/deploy/openfaas-kafka-connector/README.md
+++ b/deploy/openfaas-kafka-connector/README.md
@@ -1,0 +1,58 @@
+# openfaas-kafka-connector
+
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.6](https://img.shields.io/badge/AppVersion-1.4.6-informational?style=flat-square)
+
+A Helm chart for ratehub's openfaas kafka connector
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| basicAuthSecrets.existingSecrets | bool | `true` |  |
+| basicAuthSecrets.nameOverride | string | `""` |  |
+| basicAuthSecrets.values.basic-auth-password | string | `""` |  |
+| basicAuthSecrets.values.basic-auth-user | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"gcr.io/platform-235214/openfaas-kafka-connector"` |  |
+| image.tag | string | `""` |  |
+| imagePullSecrets[0].name | string | `"gcr-pull-secret"` |  |
+| kafkaConnectorSecrets.existingSecrets | bool | `true` |  |
+| kafkaConnectorSecrets.nameOverride | string | `""` |  |
+| kafkaConnectorSecrets.values.kafka-ssl-ca | string | `""` |  |
+| kafkaConnectorSecrets.values.kafka-ssl-cert | string | `""` |  |
+| kafkaConnectorSecrets.values.kafka-ssl-key | string | `""` |  |
+| kafkaConnectorSecrets.values.redis-pass | string | `""` |  |
+| linkerd.enabled | bool | `true` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext.fsGroup | int | `2000` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `1000` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| settings.concurrency | int | `4` |  |
+| settings.connector_name | string | `"openfaas-kafka-connector"` |  |
+| settings.gateway_ssl | bool | `false` |  |
+| settings.gateway_uri | string | `"gateway:8080"` |  |
+| settings.kafka_connection | string | `"127.0.0.1:9092"` |  |
+| settings.kafka_ssl | bool | `false` |  |
+| settings.newRelicAppName | string | `"[dev] openfaas-kafka-connector"` |  |
+| settings.newRelicEnable | bool | `false` |  |
+| settings.newRelicLicense | string | `"license_key_here"` |  |
+| settings.perFunctionJobQueue | bool | `false` |  |
+| settings.redis_connection | string | `"127.0.0.1"` |  |
+| settings.redis_port | int | `6379` |  |
+| settings.redis_ssl | bool | `false` |  |
+| tolerations | list | `[]` |  |
+

--- a/deploy/openfaas-kafka-connector/templates/NOTES.txt
+++ b/deploy/openfaas-kafka-connector/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Currently no Service or Ingress resources are used for this chart.

--- a/deploy/openfaas-kafka-connector/templates/_helpers.tpl
+++ b/deploy/openfaas-kafka-connector/templates/_helpers.tpl
@@ -1,10 +1,9 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
 {{- define "openfaas-kafka-connector.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -12,21 +11,79 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "openfaas-kafka-connector.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "openfaas-kafka-connector.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "openfaas-kafka-connector.labels" -}}
+helm.sh/chart: {{ include "openfaas-kafka-connector.chart" . }}
+{{ include "openfaas-kafka-connector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "openfaas-kafka-connector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openfaas-kafka-connector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openfaas-kafka-connector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "openfaas-kafka-connector.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Linkerd Annotations
+*/}}
+{{- define "openfaas-kafka-connector.linkerdAnnotations" -}}
+{{- if .Values.linkerd.enabled -}}
+linkerd.io/inject: enabled
+{{- else -}}
+linkerd.io/inject: disabled
+{{- end -}}
+{{- end }}
+
+{{/*
+App Secret name
+*/}}
+{{- define "openfaas-kafka-connector.app-secrets-name" -}}
+{{- $defaultSecretName := (printf "%s%s" .Release.Name "-app-secrets") -}}
+{{- default $defaultSecretName .Values.kafkaConnectorSecrets.nameOverride | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Basic-Auth Secret name
+*/}}
+{{- define "openfaas-kafka-connector.basic-auth-secrets-name" -}}
+{{- $defaultSecretName := (printf "%s%s" .Release.Name "-basic-auth-secrets") -}}
+{{- default $defaultSecretName .Values.basicAuthSecrets.nameOverride | trimSuffix "-" -}}
 {{- end -}}

--- a/deploy/openfaas-kafka-connector/templates/app-secret.yaml
+++ b/deploy/openfaas-kafka-connector/templates/app-secret.yaml
@@ -1,0 +1,16 @@
+{{- if (not .Values.kafkaConnectorSecrets.existingSecrets) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openfaas-kafka-connector.app-secrets-name" . | quote }}
+  labels:
+{{ include "openfaas-kafka-connector.labels" . | indent 4 }}
+data:
+  {{- range $key, $value := .Values.kafkaConnectorSecrets.values }}
+  {{- if eq $key "redis-pass" }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- else }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/openfaas-kafka-connector/templates/basic-auth-secret.yaml
+++ b/deploy/openfaas-kafka-connector/templates/basic-auth-secret.yaml
@@ -7,6 +7,6 @@ metadata:
 {{ include "openfaas-kafka-connector.labels" . | indent 4 }}
 data:
   {{- range $key, $value := .Values.basicAuthSecrets.values }}
-  {{ $key }}: {{ $value | quote }}
+  {{ $key }}: {{ $value | b64enc }}
   {{- end }}
 {{- end }}

--- a/deploy/openfaas-kafka-connector/templates/basic-auth-secret.yaml
+++ b/deploy/openfaas-kafka-connector/templates/basic-auth-secret.yaml
@@ -1,0 +1,12 @@
+{{- if (not .Values.basicAuthSecrets.existingSecrets) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openfaas-kafka-connector.basic-auth-secrets-name" . | quote }}
+  labels:
+{{ include "openfaas-kafka-connector.labels" . | indent 4 }}
+data:
+  {{- range $key, $value := .Values.basicAuthSecrets.values }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/openfaas-kafka-connector/templates/deployment.yaml
+++ b/deploy/openfaas-kafka-connector/templates/deployment.yaml
@@ -32,39 +32,39 @@ spec:
         - name: {{ .Chart.Name }}
           env:
             - name: CONNECTOR_NAME
-              value: {{ .Values.connector_name | quote }}
+              value: {{ .Values.settings.connector_name | quote }}
             - name: GATEWAY_URI
-              value: {{ .Values.gateway_uri | quote }}
+              value: {{ .Values.settings.gateway_uri | quote }}
             - name: GATEWAY_SSL
-              value: {{ .Values.gateway_ssl | quote  }}
-              {{- if .Values.topics }}
+              value: {{ .Values.settings.gateway_ssl | quote  }}
+              {{- if .Values.settings.topics }}
             - name: TOPICS
-              value: {{ .Values.topics | quote }}
+              value: {{ .Values.settings.topics | quote }}
               {{- end }}
-              {{- if .Values.excludeTopics }}
+              {{- if .Values.settings.excludeTopics }}
             - name: EXCLUDE_TOPICS
-              value: {{ .Values.excludeTopics | quote }}
+              value: {{ .Values.settings.excludeTopics | quote }}
               {{- end }}
             - name: KAFKA_CONNECTION
-              value: {{ .Values.kafka_connection | quote }}
+              value: {{ .Values.settings.kafka_connection | quote }}
             - name: KAFKA_SSL
-              value: {{ .Values.kafka_ssl | quote }}
+              value: {{ .Values.settings.kafka_ssl | quote }}
             - name: REDIS_CONNECTION
-              value: {{ .Values.redis_connection | quote }}
+              value: {{ .Values.settings.redis_connection | quote }}
             - name: REDIS_SSL
-              value: {{ .Values.redis_ssl | quote }}
+              value: {{ .Values.settings.redis_ssl | quote }}
             - name: REDIS_PORT
-              value: {{ .Values.redis_port | quote }}
+              value: {{ .Values.settings.redis_port | quote }}
             - name: CONCURRENCY
-              value: {{ .Values.concurrency | quote }}
+              value: {{ .Values.settings.concurrency | quote }}
             - name: CREATE_JOB_QUEUE_PER_FUNCTION
-              value: {{ .Values.perFunctionJobQueue | quote }}
+              value: {{ .Values.settings.perFunctionJobQueue | quote }}
             - name: NEW_RELIC_LICENSE_KEY
-              value: '{{.Values.newRelicLicense}}'
+              value: '{{.Values.settings.newRelicLicense}}'
             - name: NEW_RELIC_APP_NAME
-              value: '{{.Values.newRelicAppName}}'
+              value: '{{.Values.settings.newRelicAppName}}'
             - name: NEW_RELIC_ENABLED
-              value: '{{.Values.newRelicEnable}}'
+              value: '{{.Values.settings.newRelicEnable}}'
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/deploy/openfaas-kafka-connector/templates/deployment.yaml
+++ b/deploy/openfaas-kafka-connector/templates/deployment.yaml
@@ -3,35 +3,33 @@ kind: Deployment
 metadata:
   name: {{ include "openfaas-kafka-connector.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "openfaas-kafka-connector.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "openfaas-kafka-connector.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "openfaas-kafka-connector.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "openfaas-kafka-connector.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
-        linkerd.io/inject: '{{.Values.linkerd }}'
+      {{- include "openfaas-kafka-connector.linkerdAnnotations" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        app.kubernetes.io/name: {{ include "openfaas-kafka-connector.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "openfaas-kafka-connector.selectorLabels" . | nindent 8 }}
     spec:
-      volumes:
-        - name: auth
-          secret:
-            secretName: basic-auth
-        - name: connector
-          secret:
-            secretName: openfaas-connector
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        - name: '{{.Values.imagePullSecrets}}'
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "openfaas-kafka-connector.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image }}"
           env:
             - name: CONNECTOR_NAME
               value: {{ .Values.connector_name | quote }}
@@ -39,14 +37,14 @@ spec:
               value: {{ .Values.gateway_uri | quote }}
             - name: GATEWAY_SSL
               value: {{ .Values.gateway_ssl | quote  }}
-              {{ if .Values.topics }}
+              {{- if .Values.topics }}
             - name: TOPICS
               value: {{ .Values.topics | quote }}
-              {{ end }}
-              {{ if .Values.excludeTopics }}
+              {{- end }}
+              {{- if .Values.excludeTopics }}
             - name: EXCLUDE_TOPICS
               value: {{ .Values.excludeTopics | quote }}
-              {{ end }}
+              {{- end }}
             - name: KAFKA_CONNECTION
               value: {{ .Values.kafka_connection | quote }}
             - name: KAFKA_SSL
@@ -67,24 +65,49 @@ spec:
               value: '{{.Values.newRelicAppName}}'
             - name: NEW_RELIC_ENABLED
               value: '{{.Values.newRelicEnable}}'
-          volumeMounts:
-            - name: auth
-              readOnly: true
-              mountPath: "/var/secrets"
-            - name: connector
-              readOnly: true
-              mountPath: "/var/connector-secrets"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /var/secrets
+              name: auth
+              readOnly: true
+            - mountPath: /var/connector-secrets
+              name: connector
+              readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      volumes:
+        - name: auth
+          secret:
+            defaultMode: 420
+            secretName: {{ include "openfaas-kafka-connector.basic-auth-secrets-name" . | quote }}
+        - name: connector
+          secret:
+            defaultMode: 420
+            secretName: {{ include "openfaas-kafka-connector.app-secrets-name" . | quote }}

--- a/deploy/openfaas-kafka-connector/templates/deployment.yaml
+++ b/deploy/openfaas-kafka-connector/templates/deployment.yaml
@@ -69,18 +69,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 80
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /
-              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/deploy/openfaas-kafka-connector/templates/hpa.yaml
+++ b/deploy/openfaas-kafka-connector/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "openfaas-kafka-connector.fullname" . }}
+  labels:
+    {{- include "openfaas-kafka-connector.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "openfaas-kafka-connector.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/openfaas-kafka-connector/templates/serviceaccount.yaml
+++ b/deploy/openfaas-kafka-connector/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openfaas-kafka-connector.serviceAccountName" . }}
+  labels:
+    {{- include "openfaas-kafka-connector.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/openfaas-kafka-connector/values.schema.json
+++ b/deploy/openfaas-kafka-connector/values.schema.json
@@ -1,0 +1,210 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "autoscaling": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "maxReplicas": {
+                    "type": "integer"
+                },
+                "minReplicas": {
+                    "type": "integer"
+                },
+                "targetCPUUtilizationPercentage": {
+                    "type": "integer"
+                }
+            }
+        },
+        "basicAuthSecrets": {
+            "type": "object",
+            "properties": {
+                "existingSecrets": {
+                    "type": "boolean"
+                },
+                "nameOverride": {
+                    "type": "string"
+                },
+                "values": {
+                    "type": "object",
+                    "properties": {
+                        "basic-auth-password": {
+                            "type": "string"
+                        },
+                        "basic-auth-user": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "kafkaConnectorSecrets": {
+            "type": "object",
+            "properties": {
+                "existingSecrets": {
+                    "type": "boolean"
+                },
+                "nameOverride": {
+                    "type": "string"
+                },
+                "values": {
+                    "type": "object",
+                    "properties": {
+                        "kafka-ssl-ca": {
+                            "type": "string"
+                        },
+                        "kafka-ssl-cert": {
+                            "type": "string"
+                        },
+                        "kafka-ssl-key": {
+                            "type": "string"
+                        },
+                        "redis-pass": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "linkerd": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "podAnnotations": {
+            "type": "object"
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "fsGroup": {
+                    "type": "integer"
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object"
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                },
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "settings": {
+            "type": "object",
+            "properties": {
+                "concurrency": {
+                    "type": "integer"
+                },
+                "connector_name": {
+                    "type": "string"
+                },
+                "gateway_ssl": {
+                    "type": "boolean"
+                },
+                "gateway_uri": {
+                    "type": "string"
+                },
+                "kafka_connection": {
+                    "type": "string"
+                },
+                "kafka_ssl": {
+                    "type": "boolean"
+                },
+                "newRelicAppName": {
+                    "type": "string"
+                },
+                "newRelicEnable": {
+                    "type": "boolean"
+                },
+                "newRelicLicense": {
+                    "type": "string"
+                },
+                "perFunctionJobQueue": {
+                    "type": "boolean"
+                },
+                "redis_connection": {
+                    "type": "string"
+                },
+                "redis_port": {
+                    "type": "integer"
+                },
+                "redis_ssl": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array"
+        }
+    }
+}

--- a/deploy/openfaas-kafka-connector/values.yaml
+++ b/deploy/openfaas-kafka-connector/values.yaml
@@ -41,7 +41,6 @@ kafkaConnectorSecrets:
     kafka-ssl-key: '' # cat key.pem | base64
     redis-pass: ''
 
-
 basicAuthSecrets:
   existingSecrets: true
   nameOverride: ''

--- a/deploy/openfaas-kafka-connector/values.yaml
+++ b/deploy/openfaas-kafka-connector/values.yaml
@@ -4,24 +4,82 @@
 
 replicaCount: 1
 
-image: gcr.io/platform-235214/openfaas-kafka-connector:1.4.6
-imagePullSecrets: gcr-pull-secret
-connector_name: openfaas-kafka-connector
-gateway_uri: gateway:8080
-gateway_ssl: false
-#topics: test-stream-1
-#excludeTopics: test-stream-1
-kafka_connection: 127.0.0.1:9092
-kafka_ssl: false
-redis_connection: 127.0.0.1
-redis_ssl: false
-redis_port: 6379
-concurrency: 4
-perFunctionJobQueue: false
-newRelicLicense: license_key_here
-newRelicAppName: openfaas-kafka-connector
-newRelicEnable: false
-linkerd: disabled
+image:
+  repository: gcr.io/platform-235214/openfaas-kafka-connector
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets:
+  - name: gcr-pull-secret
+nameOverride: ""
+fullnameOverride: ""
+
+settings:
+  connector_name: openfaas-kafka-connector
+  gateway_uri: gateway:8080
+  gateway_ssl: false
+  #topics: test-stream-1
+  #excludeTopics: test-stream-1
+  kafka_connection: 127.0.0.1:9092
+  kafka_ssl: false
+  redis_connection: 127.0.0.1
+  redis_ssl: false
+  redis_port: 6379
+  concurrency: 4
+  perFunctionJobQueue: false
+  newRelicLicense: license_key_here
+  newRelicAppName: '[dev] openfaas-kafka-connector'
+  newRelicEnable: false
+
+kafkaConnectorSecrets:
+  existingSecrets: true
+  nameOverride: ''
+  values: # The Cert and Key files must be base64 encoded already.
+    kafka-ssl-ca: '' # cat ca.pem | base64
+    kafka-ssl-cert: '' # cat ca.crt | base64
+    kafka-ssl-key: '' # cat key.pem | base64
+    redis-pass: ''
+
+
+basicAuthSecrets:
+  existingSecrets: true
+  nameOverride: ''
+  values:
+    basic-auth-password: ''
+    basic-auth-user: ''
+
+linkerd:
+  enabled: true
+
+## The ServiceAccount is used for Vault integration.
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+  # vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local.:8200"
+  # vault.security.banzaicloud.io/vault-tls-secret: "vault-tls"
+  # vault.security.banzaicloud.io/vault-path: kubernetes
+  # vault.security.banzaicloud.io/vault-role: 
+  # vault.security.banzaicloud.io/vault-skip-verify: "true" # Container is missing Trusted Mozilla roots too.
+
+
+podSecurityContext:
+  fsGroup: 2000
+
+securityContext:
+  # capabilities:
+  #   drop:
+  #   - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -34,6 +92,13 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 


### PR DESCRIPTION
Refactor the helm chart:
 - explicitly configure the mounted secrets
 - add optional pod annotations for VSWH integration
 - ServiceAccount, pod and container security contexts added
 - values file restructured to accommodate the changes -- schema added for validation
 - helm-ci workflow added so the chart can be hosted in our chart repo